### PR TITLE
Disable timeout, implement env setting

### DIFF
--- a/pyecharts_snapshot/main.py
+++ b/pyecharts_snapshot/main.py
@@ -211,7 +211,7 @@ async def get_echarts(url: str, snapshot_js: str, config_js: str = None):
 
     page = await browser.newPage()
     # Set the timeout in async await instead
-    await page.goto(url, dict(timeout=0))
+    await page.goto(url)
 
     # Get the snapshot first
     content = await page.evaluate(snapshot_js)

--- a/pyecharts_snapshot/main.py
+++ b/pyecharts_snapshot/main.py
@@ -210,7 +210,6 @@ async def get_echarts(url: str, snapshot_js: str, config_js: str = None):
     ), args=args)
 
     page = await browser.newPage()
-    # Set the timeout in async await instead
     await page.goto(url)
 
     # Get the snapshot first

--- a/pyecharts_snapshot/main.py
+++ b/pyecharts_snapshot/main.py
@@ -210,7 +210,8 @@ async def get_echarts(url: str, snapshot_js: str, config_js: str = None):
     ), args=args)
 
     page = await browser.newPage()
-    await page.goto(url)
+    # Set the timeout in async await instead
+    await page.goto(url, dict(timeout=0))
 
     # Get the snapshot first
     content = await page.evaluate(snapshot_js)

--- a/pyecharts_snapshot/main.py
+++ b/pyecharts_snapshot/main.py
@@ -203,7 +203,12 @@ async def get_echarts(url: str, snapshot_js: str, config_js: str = None):
     """Get both the snapshot and config in a single browser session"""
     args = os.environ.get('CHROME_EXTRA_ARGS', '')
     args = args.split(' ')
-    browser = await launch(args=args)
+
+    browser = await launch(options=dict(
+        headless=(os.getenv('PYPPETEER_HEADLESS', 'true').lower() in ('true', 'yes', '1')),
+        executablePath=os.getenv('PYPPETEER_EXECUTABLE_PATH')
+    ), args=args)
+
     page = await browser.newPage()
     await page.goto(url)
 


### PR DESCRIPTION
Disable timeout, can instead rely on ray task timing (I assume this is a thing...?) out or use asynio.wait_for from within the tool. (Better than having it deeply nested or passing settings down)

Implement apparently standard envs in puppeteer (but not pyppeteer), though I didn't confirm this.
Allows setting to local chrome, as by default uses a non-arm chrome instance with performance issue on arm macs.